### PR TITLE
Wrestlr compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,10 @@ all: docs
 
 docs: README.md
 
+build:
+	mkdir -p dist && rm -r dist/*
+	python setup.py build sdist
+
 README.md: README.Rmd
 	jupytext --from Rmd --to ipynb --output - $^ \
 		| jupyter nbconvert --stdin --to markdown --execute --output $@

--- a/hoof.py
+++ b/hoof.py
@@ -66,16 +66,16 @@ def simplify_context(node, explicit = False):
         
         return siu.Call(node.__class__.__name__, node.getText())
 
+    # note: node.children is None for no match rules alternatives
     return siu.Call(
             node.__class__.__name__,
-            *map(lambda x: simplify_context(x, explicit = explicit), node.children)
+            *map(lambda x: simplify_context(x, explicit = explicit), node.children or [])
             )
 
 @to_symbol.register(AST)
 def _to_symbol_ast(x):
     from siuba.siu import Symbolic
     return Symbolic(_callify(x))
-
 
 def _callify(node):
     from siuba.siu import Call


### PR DESCRIPTION
Apparently for no match antlr alternatives, Context.children is `None` rather than an empty list.

For context a no match alternative is...

```
a_rule:    'a'
    | 'b'
    |                       // <--- no match rule, can match nothing
    ;
```
